### PR TITLE
Recreate query and client object each request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Request logging
+
+### Changed
+
+- Recreate the query and client objects for each request
+
 ## [0.0.2] - 2023-04-13
 
 ### Fixed


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

I have a suspicion that connections to Loki aren't correctly being released. I suspect its due to reusing the same client and query each time but haven't been able to confirm it.

This PR:

- add request logging
- recreated the query and client object for each incoming request

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
