### PR TITLE
Support start / end time of logs from Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for the Tekton Dashboard passing in a start / end time for the logs. (See https://github.com/tektoncd/dashboard/pull/2909)
+
 ## [0.0.3] - 2023-04-14
 
 ### Added


### PR DESCRIPTION
This PR:

- adds support for Tekton Dashboard passing in the expect start and end time of the logs its looking for. (See https://github.com/tektoncd/dashboard/pull/2909). If the start and end are provided a buffer of 1 hour is also added on to account for any possible jitter in timestamps. This is expected to be released in v0.36.0 of the Tekton Dashboard.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
