### PR TITLE
Remove parallel queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Stopped using parallel queries as they sometimes resulted in un-ordered log output
+
 ## [0.1.0] - 2023-05-16
 
 ### Added

--- a/main.go
+++ b/main.go
@@ -53,19 +53,16 @@ func main() {
 			endTime = endTime.Add(time.Hour)
 		}
 
-		parallelDuration, _ := time.ParseDuration("1h")
 		q := &query.Query{
-			Start:              startTime,
-			End:                endTime,
-			Quiet:              true,
-			NoLabels:           true,
-			Limit:              0,
-			BatchSize:          5000,
-			ColoredOutput:      false,
-			ParallelMaxWorkers: 3,
-			ParallelDuration:   parallelDuration,
-			Forward:            true,
-			QueryString:        fmt.Sprintf(`{container="%s",namespace="%s",pod="%s"}`, c.Params("container"), c.Params("namespace"), c.Params("pod")),
+			Start:         startTime,
+			End:           endTime,
+			Quiet:         true,
+			NoLabels:      true,
+			Limit:         0,
+			BatchSize:     5000,
+			ColoredOutput: false,
+			Forward:       true,
+			QueryString:   fmt.Sprintf(`{container="%s",namespace="%s",pod="%s"}`, c.Params("container"), c.Params("namespace"), c.Params("pod")),
 		}
 
 		out, err := output.NewLogOutput(c.Response().BodyWriter(), "raw", &output.LogOutputOptions{
@@ -76,7 +73,7 @@ func main() {
 			return err
 		}
 
-		q.DoQueryParallel(&client.DefaultClient{
+		q.DoQuery(&client.DefaultClient{
 			TLSConfig: config.TLSConfig{},
 			OrgID:     orgID,
 			Address:   lokiEndpoint,


### PR DESCRIPTION
This PR:

- Removes parallel queries as they sometimes resulted in the log output being out of order as there was no guarantee that the queries return in order

Fixes https://github.com/giantswarm/roadmap/issues/2557

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
