### PR TITLE
Change `app.giantswarm.io/*` labels to `application.giantswarm.io/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change `app.giantswarm.io/*` labels to `application.giantswarm.io/`
+
 ## [0.3.0] - 2024-02-01
 
 ### Added

--- a/helm/tekton-dashboard-loki-proxy/templates/_helpers.tpl
+++ b/helm/tekton-dashboard-loki-proxy/templates/_helpers.tpl
@@ -27,9 +27,9 @@ Common labels
 {{- define "labels.common" -}}
 {{ include "labels.selector" . }}
 app: {{ include "name" . | quote }}
-app.giantswarm.io/branch: {{ .Values.project.branch | quote }}
-app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
-app.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+application.giantswarm.io/branch: {{ .Values.project.branch | quote }}
+application.giantswarm.io/commit: {{ .Values.project.commit | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 giantswarm.io/managed-by: {{ .Release.Name | quote }}


### PR DESCRIPTION
### This PR:

- changes the chart labels prefixed `app.giantswarm.io/` to `application.giantswarm.io/`, as the latter is now the canonical version.

For reference: https://github.com/giantswarm/giantswarm/issues/30245

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
